### PR TITLE
Possibly fix Double Strike bug

### DIFF
--- a/Assets/GuessWhoScript.cs
+++ b/Assets/GuessWhoScript.cs
@@ -783,7 +783,7 @@ public class GuessWhoScript : MonoBehaviour
 			TheTrue.text = "Not\nRight";
 		}	
 		
-		if (StackNumber == 300)
+		else if (StackNumber == 300)
 		{
 			FirstDisplay.color = Color.red;
 			SecondDisplay.color = Color.red;
@@ -827,7 +827,7 @@ public class GuessWhoScript : MonoBehaviour
 			TheTrue.text = "You\nGot It";
 		}	
 		
-		if (StackNumber == 300)
+		else if (StackNumber == 300)
 		{
 			FirstDisplay.color = Color.green;
 			SecondDisplay.color = Color.green;


### PR DESCRIPTION
The NotCopyCat() Coroutine was called many times, and there was a possibility that two of the times that it was called could have both striked. This changes it so that it can only be called once.